### PR TITLE
Fix requirements parsing in setup.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,34 +1,73 @@
-# Compiled python modules.
-*.pyc
+### https://raw.github.com/github/gitignore/master/Python.gitignore
 
-# Setuptools build and distribution folder.
-/dist/
-/build/
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
 
-# Python egg metadata, regenerated from source files by setuptools.
-/*.egg-info
+# C extensions
+*.so
 
-# Sublime text project files
-*.sublime-project
-*.sublime-workspace
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
 
-#Tox
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
 .tox/
-
-#venv
-.venv/
-
-#DS Store files
-.DS_Store
-
-#Nosetests XML report
-nosetests.xml
-
-#PyCharm project
-.idea/
-
-#Coverage
 .coverage
+.cache
+nosetests.xml
+coverage.xml
 
-#Sphinx build dir
-docs/build
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+
+### https://raw.github.com/github/gitignore/master/Global/Virtualenv.gitignore
+
+# Virtualenv
+# http://iamzed.com/2009/05/07/a-primer-on-virtualenv/
+.Python
+[Bb]in
+[Ii]nclude
+[Ll]ib
+[Ss]cripts
+pyvenv.cfg
+
+### Local
+
+# Files created from tests...
+hm-1.0.0-SNAPSHOT.zip

--- a/hpsdnclient/datatypes.py
+++ b/hpsdnclient/datatypes.py
@@ -259,8 +259,8 @@ class JsonObject(object):
     def to_dict(self):
         data = {}
         attributes = [attr for attr in dir(self)
-                      if not callable(getattr(self, attr))
-                      and not attr.startswith("__")]
+                      if not callable(getattr(self, attr)) and
+                      not attr.startswith("__")]
         for attr in attributes:
             if getattr(self, attr) is not None:
                 value = getattr(self, attr)
@@ -297,8 +297,8 @@ class JsonObject(object):
 
     def __eq__(self, other):
         attributes = [attr for attr in dir(self)
-                      if not callable(getattr(self, attr))
-                      and not attr.startswith("__")]
+                      if not callable(getattr(self, attr)) and
+                      not attr.startswith("__")]
         for attr in attributes:
             try:
                 if self.__getattribute__(attr) == other.__getattribute__(attr):
@@ -508,8 +508,8 @@ class Match(JsonObject):
         """
         data = []
         attributes = [attr for attr in dir(self)
-                      if not callable(getattr(self, attr))
-                      and not attr.startswith("__")]
+                      if not callable(getattr(self, attr)) and
+                      not attr.startswith("__")]
         for attr in attributes:
             if getattr(self, attr):
                 tmp = {}
@@ -554,8 +554,8 @@ class Action(JsonObject):
         """
         data = []
         attributes = [attr for attr in dir(self)
-                      if not callable(getattr(self, attr))
-                      and not attr.startswith("__")]
+                      if not callable(getattr(self, attr)) and
+                      not attr.startswith("__")]
         for attr in attributes:
             if attr == "output":
                 output = getattr(self, attr)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
-requests>=2.0.1
-distribute>=0.7.3
+--index-url https://pypi.python.org/simple/
+
+-e .

--- a/setup.py
+++ b/setup.py
@@ -16,18 +16,11 @@
 
 import os
 from setuptools import setup
-from pip.req import parse_requirements
 
 # Get version from hpsdclient.version in a PY3 safe manner
 with open("hpsdnclient/version.py") as f:
     code = compile(f.read(), "hpsdnclient/version.py", 'exec')
     exec(code)
-
-
-def requires(filename):
-    requirements = parse_requirements(os.path.abspath(filename))
-    return [str(r.req) for r in requirements]
-
 
 def readme():
     with open('README.rst') as f:
@@ -57,8 +50,19 @@ setup(
     license='Apache License, Version 2.0',
     packages=['hpsdnclient'],
     include_package_data=True,
-    install_requires=requires('requirements.txt'),
+    install_requires=[
+        "distribute",
+        "requests"
+    ],
     test_suite='nose.collector',
-    tests_require=requires('test-requirements.txt'),
+    tests_require=[
+        "tox",
+        "nose",
+        "coverage==3.7.1",
+        "mock",
+        "httpretty>=0.8.0",
+        "flake8==2.2.2",
+        "python-coveralls"
+    ],
     zip_safe=False,
 )

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,6 +1,6 @@
 tox
 nose
-coverage
+coverage==3.7.1
 mock
 httpretty>=0.8.0
 flake8==2.2.2


### PR DESCRIPTION
The method recommended to avoid duplication between `requirements.txt`
and `setup.py` recommended in StackOverflow [1] no longer works due to a
signature change in the parse_requirements method in `pip`

Instead, we use [2]. `requirements.txt` defers to `setup.py`
We use "abstract requirements" in `setup.py` as we're a library.

`test-requirements.txt` remains intact though it's much cleaner to use:

```bash
pip install -r test-requirements.txt
tox -e py27
```
vs. `python setup.py test` as there is no control over the options
passed to tox

As such, `tests_require` is probably candidate for deletion.

[1]
http://stackoverflow.com/questions/14399534/how-can-i-reference-requirements-txt-for-the-install-requires-kwarg-in-setuptool
[2] https://caremad.io/2013/07/setup-vs-requirement/
Signed-off-by: Dave Tucker <dave@dtucker.co.uk>